### PR TITLE
Fix scraper integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,27 @@ Each folder contains a README with setup instructions. The scraper now exposes a
 The backend uses the Gmail API to send applications for jobs that expose recruiter emails.
 Users authenticate with JWT and can upload their CV which is required for sending applications.
 The React client includes a subscribe page at `/subscribe` which opens Razorpay Checkout to activate a user subscription.
+
+## Running locally
+
+Start the backend API:
+
+```bash
+cd server
+npm install
+npm run dev
+```
+
+This launches Express on [http://localhost:5000](http://localhost:5000).
+
+In another terminal, start the React development server:
+
+```bash
+cd client
+npm install
+npm run dev
+```
+
+Vite prints the URL to open in your browser, typically
+[http://localhost:5173](http://localhost:5173). If that port is taken it will
+increment (5174, 5175, ...). Use the port shown in the terminal.

--- a/server/index.js
+++ b/server/index.js
@@ -71,10 +71,13 @@ app.post('/scrape', auth, requireSubscription, async (req, res) => {
 
 app.post('/api/jobs/scrape', auth, requireSubscription, async (req, res) => {
   const { keywords = '', location = '' } = req.body || {};
-  const scraperUrl = process.env.SCRAPER_URL || 'http://localhost:5000';
+  const scraperUrl = process.env.SCRAPER_URL || 'http://localhost:8000';
   try {
-    const params = new URLSearchParams({ keywords, location }).toString();
-    const resp = await fetch(`${scraperUrl}/scrape?${params}`);
+    const resp = await fetch(`${scraperUrl}/scrape`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: keywords, location }),
+    });
     const jobs = await resp.json();
     const saved = await Promise.all(
       jobs.map((job) =>


### PR DESCRIPTION
## Summary
- correct scraper integration endpoint: use POST instead of GET and default to port 8000

## Testing
- `node --check index.js`
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6842a16609b8833194d72a4892ef498c